### PR TITLE
Added show instance for ConnectInfo.

### DIFF
--- a/Database/MySQL/Connection.hs
+++ b/Database/MySQL/Connection.hs
@@ -63,7 +63,7 @@ data ConnectInfo = ConnectInfo
     , ciUser     :: ByteString
     , ciPassword :: ByteString
     , ciCharset  :: Word8
-    }
+    } deriving Show
 
 -- | A simple 'ConnectInfo' targeting localhost with @user=root@ and empty password.
 --

--- a/mysql-haskell.cabal
+++ b/mysql-haskell.cabal
@@ -45,7 +45,7 @@ library
                     ,   bytestring    >= 0.10.2.0
                     ,   text          >= 1.1 && < 1.3
                     ,   cryptonite    == 0.*
-                    ,   memory
+                    ,   memory        <= 0.14.2
                     ,   time          >= 1.5.0
                     ,   scientific    == 0.3.*
                     ,   bytestring-lexing == 0.5.*


### PR DESCRIPTION
This addresses orphan instance warning in [persistent-mysql-haskell](https://github.com/naushadh/persistent/blob/persistent-mysql-haskell/persistent-mysql-haskell/Database/Persist/MySQL.hs#L927).