### PR TITLE
Exported types for convenience.

### DIFF
--- a/Database/MySQL/Base.hs
+++ b/Database/MySQL/Base.hs
@@ -58,6 +58,8 @@ module Database.MySQL.Base
     , renderParams
     , command
     , Stream.skipToEof
+    , HostName
+    , PortNumber
       -- * Exceptions
     , NetworkException(..)
     , UnconsumedResultSet(..)
@@ -89,6 +91,7 @@ import           Database.MySQL.Query
 import           System.IO.Streams                  (InputStream, OutputStream)
 import qualified System.IO.Streams                  as Stream
 import qualified Data.Vector                        as V
+import           Network.Socket                     (HostName, PortNumber)
 
 --------------------------------------------------------------------------------
 

--- a/Database/MySQL/TLS.hs
+++ b/Database/MySQL/TLS.hs
@@ -15,6 +15,7 @@ module Database.MySQL.TLS (
       connect
     , connectDetail
     , module Data.TLSSetting
+    , TLS.ClientParams
     ) where
 
 import           Control.Exception              (bracketOnError, throwIO)


### PR DESCRIPTION
A user library/program had to include tls and/or network libs just to access the types of ClientParams, PortNumber and HostName. Re-export them so user code can access them easier.