### PR TITLE
Stackage lts9 - `memory` bounds

### DIFF
--- a/mysql-haskell.cabal
+++ b/mysql-haskell.cabal
@@ -83,6 +83,5 @@ test-suite test
                   , vector
     default-extensions:     MultiWayIf
                         ,   OverloadedStrings
-
     ghc-options:         -threaded
     default-language:    Haskell2010

--- a/mysql-haskell.cabal
+++ b/mysql-haskell.cabal
@@ -6,7 +6,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              winterland1989
 maintainer:          winterland1989@gmail.com
-copyright:           (c) 2016 Winterland       
+copyright:           (c) 2016 Winterland
 category:            Database
 build-type:          Simple
 extra-source-files:  ChangeLog.md, README.md
@@ -20,7 +20,7 @@ source-repository head
 
 library
     exposed-modules:    Database.MySQL.Base
-                    ,   Database.MySQL.TLS       
+                    ,   Database.MySQL.TLS
                     ,   Database.MySQL.Protocol.Auth
                     ,   Database.MySQL.Protocol.Command
                     ,   Database.MySQL.Protocol.ColumnDef
@@ -45,7 +45,7 @@ library
                     ,   bytestring    >= 0.10.2.0
                     ,   text          >= 1.1 && < 1.3
                     ,   cryptonite    == 0.*
-                    ,   memory        <= 0.14.2
+                    ,   memory        >= 0.14.4 && < 0.15
                     ,   time          >= 1.5.0
                     ,   scientific    == 0.3.*
                     ,   bytestring-lexing == 0.5.*


### PR DESCRIPTION
[#2334](https://github.com/fpco/stackage/issues/2334) lists 3 tasks. The `memory` bounds issue specifically looked like something that can be fixed right away (without any code changes) for lts-9 compatibility, since tcp-streams [is pegged at 0.6.0.0](https://www.stackage.org/lts-9.0/package/tcp-streams-0.6.0.0).

I'd like to get both `mysql-haskell` and `persistent-mysql-haskell` back on stackage. Please advice if this is all we need or if I should also look into tcp-streams-1.0 compatibility.