### PR TITLE
Fix #16: Updated for `tcp-streams` 1.0 compatibility.

### DIFF
--- a/mysql-haskell.cabal
+++ b/mysql-haskell.cabal
@@ -37,7 +37,7 @@ library
                     ,   monad-loops   == 0.4.*
                     ,   network       >= 2.3 && < 3.0
                     ,   io-streams    >= 1.2 && < 2.0
-                    ,   tcp-streams   >= 0.6 && < 0.7
+                    ,   tcp-streams   >= 1.0 && < 1.1
                     ,   wire-streams  >= 0.1
                     ,   binary        >= 0.8.3
                     ,   binary-ieee754


### PR DESCRIPTION
### Fix #16: Updated for `tcp-streams` 1.0 compatibility.
- Updated .cabal dep `tcp-streams` min-bound to 1.0 since there is a drastically different API between pre 1.0 and post 1.0.
- Updated .cabal dep `tcp-streams` max-bound to 1.1 since it seems like the thing to do.
- Updated `Database.MySQL.Connection` type `MySQLConn` to replace `OutputStream Packet` with `Packet -> IO ()`
  - since we no longer have access to an `OutputStream` in the latest `tcp-streams` version
  - and it is somewhat redundant to have an `OutputStream` when every action/usage only ever "writes" a `Just` value to it
- Updated `Database.MySQL.Connection`, `Database.MySQL.TLS`, and `Database.MySQL.BinLog` to adapt to earlier type change.
- Updated `Database.MySQL.TLS` to delegate handshaking to the latest `System.IO.Streams.TLS` (which does it for us using `connect`).