### PR TITLE
Send close packet

### DIFF
--- a/Database/MySQL/Connection.hs
+++ b/Database/MySQL/Connection.hs
@@ -120,7 +120,7 @@ connectDetail (ConnectInfo host port db user pass charset)
       if isOK q
       then do
           consumed <- newIORef True
-          let conn = MySQLConn is' (write c) (TCP.close c) consumed
+          let conn = MySQLConn is' (write c) (writeCommand COM_QUIT (write c) >> TCP.close c) consumed
           return (greet, conn)
       else TCP.close c >> decodeFromPacket q >>= throwIO . ERRException
 


### PR DESCRIPTION
I noticed following messages in my mysql log:
`[Note] Aborted connection *** to db: '***' user: '***' host: '***' (Got an error reading communication packets)`

This happens when a connection gets closed without sending a close packet, which is currently the case in mysql-haskell.