### PR TITLE
Relax `tasty` version bound to build with latest stackage.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for mysql-haskell
 
+## 0.8.5.0 -- 2018-10-23
+
+* Relax `tasty` version bound to build with latest stackage. [#26](https://github.com/winterland1989/mysql-haskell/pull/26)
+
 ## 0.8.4.0  -- 2018-10-23
 
 * Add `executeMany_` to execute batch SQLs, [#26](https://github.com/winterland1989/mysql-haskell/issues/26).

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,6 @@
 # Revision history for mysql-haskell
 
-## 0.8.5.0 -- 2018-10-23
+## 0.8.4.1 -- 2018-10-23
 
 * Relax `tasty` version bound to build with latest stackage. [#26](https://github.com/winterland1989/mysql-haskell/pull/26)
 

--- a/mysql-haskell.cabal
+++ b/mysql-haskell.cabal
@@ -1,5 +1,5 @@
 name:                mysql-haskell
-version:             0.8.5.0
+version:             0.8.4.1
 synopsis:            pure haskell MySQL driver
 description:         pure haskell MySQL driver
 license:             BSD3

--- a/mysql-haskell.cabal
+++ b/mysql-haskell.cabal
@@ -1,5 +1,5 @@
 name:                mysql-haskell
-version:             0.8.4.0
+version:             0.8.5.0
 synopsis:            pure haskell MySQL driver
 description:         pure haskell MySQL driver
 license:             BSD3
@@ -75,7 +75,7 @@ test-suite test
     build-depends:  mysql-haskell
                   , base
                   , bytestring
-                  , tasty == 0.11.*
+                  , tasty >= 0.11 && < 2.0
                   , tasty-hunit
                   , text
                   , io-streams


### PR DESCRIPTION
Latest stackage nightly has upgraded `tasty` version 1, and it appears everything still works with just a simple bounds change.