### PR TITLE
Fix stackage#4312: Relax `network` bounds.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for mysql-haskell
 
+## 0.8.4.2 -- 2019-01-22
+
+* Fix [stackage#4312](https://github.com/commercialhaskell/stackage/issues/4312): Relax `network` bounds.
+
 ## 0.8.4.1 -- 2018-10-23
 
 * Relax `tasty` version bound to build with latest stackage. [#26](https://github.com/winterland1989/mysql-haskell/pull/26)

--- a/mysql-haskell.cabal
+++ b/mysql-haskell.cabal
@@ -1,5 +1,5 @@
 name:                mysql-haskell
-version:             0.8.4.1
+version:             0.8.4.2
 synopsis:            pure haskell MySQL driver
 description:         pure haskell MySQL driver
 license:             BSD3
@@ -35,7 +35,7 @@ library
     other-modules:      Database.MySQL.Query
     build-depends:      base          >= 4.7 && < 5
                     ,   monad-loops   == 0.4.*
-                    ,   network       >= 2.3 && < 3.0
+                    ,   network       >= 2.3 && < 4.0
                     ,   io-streams    >= 1.2 && < 2.0
                     ,   tcp-streams   >= 1.0 && < 1.1
                     ,   wire-streams  >= 0.1


### PR DESCRIPTION
See stackage issue: https://github.com/commercialhaskell/stackage/issues/4312

Tested network-3.0.0.0 compat using the following `stack.yaml`

```yaml
resolver: lts-13.4
packages:
  - .
extra-deps:
- network-3.0.0.0
# - network-2.6.3.6
- tcp-streams-1.0.1.1
- git: git@github.com:naushadh/io-streams.git
  commit: 8ebb795b86e20d60ba6fdbbb25c3cb1ef90b2d98
```