### PR TITLE
Allow GHC 8.8

### DIFF
--- a/Database/MySQL/Protocol/Command.hs
+++ b/Database/MySQL/Protocol/Command.hs
@@ -83,7 +83,7 @@ putCommand (COM_STMT_EXECUTE stid params nullmap) = do
 
 putCommand (COM_STMT_CLOSE stid) = putWord8 0x19 >> putWord32le stid
 putCommand (COM_STMT_RESET stid) = putWord8 0x1A >> putWord32le stid
-putCommand _                     = fail "unsupported command"
+putCommand _                     = error "unsupported command"
 
 --------------------------------------------------------------------------------
 --  Prepared statment related

--- a/mysql-haskell.cabal
+++ b/mysql-haskell.cabal
@@ -45,13 +45,13 @@ library
                     ,   bytestring    >= 0.10.2.0
                     ,   text          >= 1.1 && < 1.3
                     ,   cryptonite    == 0.*
-                    ,   memory        >= 0.14.4 && < 0.15
+                    ,   memory        >= 0.14.4 && < 0.16
                     ,   time          >= 1.5.0
                     ,   scientific    == 0.3.*
                     ,   bytestring-lexing == 0.5.*
                     ,   blaze-textual     == 0.2.*
                     ,   word24            >= 1.0 && <= 3.0
-                    ,   tls           >= 1.3.5 && < 1.5
+                    ,   tls           >= 1.3.5 && < 1.6
                     ,   vector        >= 0.8
 
     default-language:    Haskell2010


### PR DESCRIPTION
- Bumped version upper bounds of memory & tls
- Replaced 'fail' with 'error' in putCommand in line with MonadFail Proposal

For #36 