### PR TITLE
Add CLIENT_MULTI_RESULTS

### DIFF
--- a/Database/MySQL/Protocol/Auth.hs
+++ b/Database/MySQL/Protocol/Auth.hs
@@ -181,6 +181,7 @@ clientCap =  CLIENT_LONG_PASSWORD
                 .|. CLIENT_PROTOCOL_41
                 .|. CLIENT_TRANSACTIONS
                 .|. CLIENT_MULTI_STATEMENTS
+                .|. CLIENT_MULTI_RESULTS
                 .|. CLIENT_SECURE_CONNECTION
 
 clientMaxPacketSize :: Word32


### PR DESCRIPTION
According to [MySQL documentation](https://dev.mysql.com/doc/c-api/8.0/en/c-api-multiple-queries.html) `CLIENT_MULTI_STATEMENTS` implies `CLIENT_MULTI_RESULTS`, so we should also send that in the protocol.

See https://github.com/sysown/proxysql/issues/2619 for more context.