### PR TITLE
Add support for `text` 2.0

### DIFF
--- a/mysql-haskell.cabal
+++ b/mysql-haskell.cabal
@@ -43,15 +43,15 @@ library
                     ,   binary-ieee754
                     ,   binary-parsers >= 0.2.1
                     ,   bytestring    >= 0.10.2.0
-                    ,   text          >= 1.1 && < 1.3
+                    ,   text          >= 1.1
                     ,   cryptonite    == 0.*
-                    ,   memory        >= 0.14.4 && < 0.16
+                    ,   memory        >= 0.14.4 && < 0.18
                     ,   time          >= 1.5.0
                     ,   scientific    == 0.3.*
                     ,   bytestring-lexing == 0.5.*
                     ,   blaze-textual     == 0.2.*
                     ,   word24            >= 1.0 && <= 3.0
-                    ,   tls           >= 1.3.5 && < 1.6
+                    ,   tls           >= 1.3.5 && < 1.7
                     ,   vector        >= 0.8
 
     default-language:    Haskell2010


### PR DESCRIPTION
This PR adds support for this library to be used with `text` versions 2.0 and up. From 2.0 on, `text` uses UTF-8 encoding internally, where it used to rely UTF-16. This broke the `escapeText` function, as this directly accesses the internal text array. I've fixed this to work for UTF-8 if GHC detects `text >= 2.0`.

Additionally, the version constraints for for `memory` and `tls` have been loosened a bit.