### PR TITLE
Fix benchmark compilation failures

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,14 @@
 # Revision history for mysql-haskell
 
-## 1.2.3 -- 2026.04.12 
+## 1.2.4 -- 2026.04.20
++ Fix benchmark compilation failures (#82):
+  + Replace deleted `Data.Binary.Parser.Char8` import in benchmark with
+    `Word8`-based combinators from `Data.Binary.Parser`
+  + Replace `GHC.Prim`/`GHC.Types` imports with `GHC.Exts` from `base`
+  + Fix `Word8#` vs `Word#` type mismatch in `mhDigitToInt`
+  + Remove stale haddock reference to deleted `Char8` module
+
+## 1.2.3 -- 2026.04.12
 + Support caching_sha2_password full auth via RSA on non-TLS connections#81 thanks @ikaro1192
 
 ## 1.2.2 -- 2026.03.25

--- a/binary-parser-bench/HttpReq.hs
+++ b/binary-parser-bench/HttpReq.hs
@@ -13,7 +13,6 @@ import qualified Data.Attoparsec.ByteString as AP
 import qualified Data.Attoparsec.ByteString.Char8 as APC
 import qualified Data.ByteString.Char8 as BC
 import qualified Data.Binary.Parser as BP
-import qualified Data.Binary.Parser.Char8 as BPC
 import Network.HTTP.Types.Version (HttpVersion, http11)
 import qualified Scanner as SC
 
@@ -59,20 +58,21 @@ attoManyHeader = do
 --------------------------------------------------------------------------------
 
 bpHeader = do
-  name <- BPC.takeWhile1 isHeaderChar <* BPC.char ':' <* BP.skipSpaces
+  name <- BP.takeWhile1 isHeaderWord8 <* BP.word8 (c2w ':') <* BP.skipSpaces
   body <- bpBodyLine
   return (name, body)
   where
-    isHeaderChar c = ('a' <= c && c <= 'z')
-                  || ('A' <= c && c <= 'Z')
-                  || ('0' <= c && c <= '0')
-                  || c == '_' || c == '-'
+    isHeaderWord8 w = let c = w2c w in
+                   ('a' <= c && c <= 'z')
+                || ('A' <= c && c <= 'Z')
+                || ('0' <= c && c <= '0')
+                || c == '_' || c == '-'
 
-bpBodyLine = BPC.takeTill (\c -> c == '\r' || c == '\n') <* BP.endOfLine
+bpBodyLine = BP.takeTill (\w -> w == 13 || w == 10) <* BP.endOfLine
 
 bpReqLine = do
-  m <- (BPC.takeTill BPC.isSpace <* BPC.char ' ')
-  (p,q) <- BC.break (=='?') <$> (BPC.takeTill BPC.isSpace <* BPC.char ' ')
+  m <- (BP.takeTill BP.isSpace <* BP.word8 (c2w ' '))
+  (p,q) <- BC.break (=='?') <$> (BP.takeTill BP.isSpace <* BP.word8 (c2w ' '))
   v <- bpHttpVersion
   return (m,p,q,v)
 
@@ -81,7 +81,8 @@ bpHttpVersion = http11 <$ BP.string "HTTP/1.1"
 bpRequest = (,) <$> (bpReqLine <* BP.endOfLine) <*> bpManyHeader
 
 bpManyHeader = do
-  c <- BPC.peek
+  w <- BP.peek
+  let c = w2c w
   if c == '\r' || c == '\n'
     then return []
     else (:) <$> bpHeader <*> bpManyHeader

--- a/binary-parser-bench/Network/Wai/Handler/Warp/ReadInt.hs
+++ b/binary-parser-bench/Network/Wai/Handler/Warp/ReadInt.hs
@@ -16,8 +16,7 @@ module Network.Wai.Handler.Warp.ReadInt (
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as S
 import Data.Int (Int64)
-import GHC.Prim
-import GHC.Types
+import GHC.Exts (Addr#, Int(..), indexWord8OffAddr#, word2Int#, word8ToWord#)
 import GHC.Word
 
 {-# INLINE readInt #-}
@@ -41,7 +40,7 @@ data Table = Table !Addr#
 
 {-# NOINLINE mhDigitToInt #-}
 mhDigitToInt :: Word8 -> Int
-mhDigitToInt (W8# i) = I# (word2Int# (indexWord8OffAddr# addr (word2Int# i)))
+mhDigitToInt (W8# i) = I# (word2Int# (word8ToWord# (indexWord8OffAddr# addr (word2Int# (word8ToWord# i)))))
   where
     !(Table addr) = table
     table :: Table

--- a/mysql-haskell.cabal
+++ b/mysql-haskell.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.4
 name:               mysql-haskell
-version:            1.2.3
+version:            1.2.4
 synopsis:           pure haskell MySQL driver
 description:        pure haskell MySQL driver.
 license:            BSD-3-Clause

--- a/src/Data/Binary/Parser.hs
+++ b/src/Data/Binary/Parser.hs
@@ -11,8 +11,7 @@
 -- This library provide parsec\/attoparsec style parsing combinators for
 -- <http://hackage.haskell.org/package/binary binary>
 -- package. By default, this module export combinators in "Data.Binary.Get",
--- "Data.Binary.Parser.Word8" and "Data.Binary.Parser.Numeric", for additional ASCII char parser,
--- please check "Data.Binary.Parser.Char8" module.
+-- "Data.Binary.Parser.Word8" and "Data.Binary.Parser.Numeric".
 --
 -- The behaviour of parsers here is different to that of the
 -- similarly-named parser in Parsec, as this one is all-or-nothing.


### PR DESCRIPTION
## Summary
- Rewrote `HttpReq.hs` benchmark to use `Word8`-based combinators from `Data.Binary.Parser` instead of the deleted `Data.Binary.Parser.Char8` module (removed in v1.1.0)
- Replaced `GHC.Prim`/`GHC.Types` imports in `ReadInt.hs` with `GHC.Exts` from `base`, eliminating the need for `ghc-prim` in `build-depends`
- Fixed `Word8#` vs `Word#` type mismatch in `mhDigitToInt` using `word8ToWord#` conversions
- Removed stale haddock reference to the deleted `Char8` module

Fixes #82

## Test plan
- [x] Reproduced both compilation errors locally on GHC 9.10.3
- [x] `cabal build --enable-benchmarks --enable-tests` passes
- [x] All 146 unit tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)